### PR TITLE
chore: update axe puppeteer to @next version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -787,16 +787,16 @@
 			"dev": true
 		},
 		"axe-core": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.2.2.tgz",
-			"integrity": "sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA=="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.1.tgz",
+			"integrity": "sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ=="
 		},
 		"axe-puppeteer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/axe-puppeteer/-/axe-puppeteer-1.0.0.tgz",
-			"integrity": "sha512-hTF3u4mtatgTN7fsLVyVgbRdNc15ngjDcTEuqhn9A7ugqLhLCryJWp9fzqZkNlrW8awPcxugyTwLPR7mRdPZmA==",
+			"version": "0.1.0-canary.8ffaefb1",
+			"resolved": "https://registry.npmjs.org/axe-puppeteer/-/axe-puppeteer-0.1.0-canary.8ffaefb1.tgz",
+			"integrity": "sha512-O053DqsP7M35rZuKvCiRVVqupXbora+/Zv62HeGSY8U5NoytOFZf1vScjD3+72OGOz1jx9lwUuYh4HBjEzbKRQ==",
 			"requires": {
-				"axe-core": "^3.1.2"
+				"axe-core": "^3.3.1"
 			}
 		},
 		"babel-jest": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"homepage": "https://github.com/act-rules/act-rules-implementation-axe-core#readme",
 	"dependencies": {
 		"assert": "^2.0.0",
-		"axe-puppeteer": "^1.0.0",
+		"axe-puppeteer": "next",
 		"commander": "^2.20.0",
 		"puppeteer": "^1.18.0",
 		"static-server": "^2.2.1"


### PR DESCRIPTION
- always default to latest of [axe-puppeteer](https://www.npmjs.com/package/axe-puppeteer)