### PR TITLE
fix: manually map rule  `meta viewport does not prevent zoom` (b4f0c3) to `axe-core` rule

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,8 +36,17 @@ const rulesAxeOptions = {
   }
 }
 
+const manualRulesMapping = {
+  /**
+   * Rule: meta viewport does not prevent zoom
+   * Url: https://act-rules.github.io/rules/b4f0c3
+   */
+  'b4f0c3': ['meta-viewport']
+}
+
 module.exports = {
   ignoreRulesIds,
   inapplicableFileExtensions,
-  rulesAxeOptions
+  rulesAxeOptions,
+  manualRulesMapping
 }


### PR DESCRIPTION
Creating a manual mapping for the above rule, to allow to generate axe implementation results.

Closes Issue:
- https://github.com/act-rules/act-rules-implementation-axe-core/issues/17